### PR TITLE
ignore query string in getExtension

### DIFF
--- a/lib/resolveAsset.js
+++ b/lib/resolveAsset.js
@@ -59,6 +59,7 @@ function getExtension(url) {
   return url
     .split('.')
     .pop()
+    .split('?')[0]
     .toLowerCase();
 }
 

--- a/lib/resolveAsset.js
+++ b/lib/resolveAsset.js
@@ -51,8 +51,8 @@ async function getImageSizeAsync({ url }) {
   );
 }
 
-function isImageUrl(url) {
-  return url.match(/\.(jpeg|jpg|gif|png)$/) != null;
+function isImageType(type) {
+  return type.match(/(jpeg|jpg|gif|png)$/) != null;
 }
 
 function getExtension(url) {
@@ -73,7 +73,7 @@ async function assetFromUriAsync({ uri: fileuri, name: filename }) {
     const type = getExtension(name);
     let width = undefined;
     let height = undefined;
-    if (isImageUrl(name)) {
+    if (isImageType(type)) {
       const size = await getImageSizeAsync({ url: uri });
       width = size.width;
       height = size.height;


### PR DESCRIPTION
`getExtension()` is used to determine the extension from a uri.
Some services, such as Firebase Storage, append additional information to the end of the uri in the form of a query string.

- Update the `getExtension()` logic to remove any text appearing after the first `'?'`, as well as the `'?'` itself.
- Change `isImageUrl()` to `isImageType()` and pass in the extension rather than the URL

