### PR TITLE
Planes Detection, World Alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ return an (`array`) of points:
 * z
 * id
 
+### `ExpoTHREE.getPlanes()`
+
+Given an `arSession` from `NativeModules.ExponentGLViewManager.startARSession`,
+return an (`array`) of horizontal planes:
+
+* center (x,y,z)
+* extent (width, length)
+* transform (4x4 matrix)
+* id
+
 ### `ExpoTHREE.setIsLightEstimationEnabled()`
 
 Given an `arSession` from `NativeModules.ExponentGLViewManager.startARSession`
@@ -85,6 +95,11 @@ and a `bool`, Enable or disable light estimation.
 
 Given an `arSession` from `NativeModules.ExponentGLViewManager.startARSession`
 and a `bool`, sets the type of planes to detect in the scene.
+
+### `ExpoTHREE.setWorldAlignment()`
+
+Given an `arSession` from `NativeModules.ExponentGLViewManager.startARSession`
+and one of `ExpoTHREE.WorldAlignment.Gravity`, `ExpoTHREE.WorldAlignment.GravityAndHeading`, `ExpoTHREE.WorldAlignment.Camera`, sets the world alignment.
 
 ### `ExpoTHREE.utils`
 

--- a/lib/ExpoTHREE.js
+++ b/lib/ExpoTHREE.js
@@ -122,6 +122,25 @@ export const setIsLightEstimationEnabled = (arSession, isEnabled) => {
 };
 
 /**
+ Set scene world alignment. Possible values are:
+  - ExpoTHREE.WorldAlignment.Gravity
+  - ExpoTHREE.WorldAlignment.GravityAndHeading
+  - ExpoTHREE.WorldAlignment.Camera
+ 
+ @discussion By default ExpoTHREE.WorldAlignment.Gravity is used.
+
+ setWorldAlignment
+ */
+export const setWorldAlignment = (arSession, worldAlignment) => {
+  return NativeModules.ExponentGLViewManager.setWorldAlignment(
+    arSession.sessionId,
+    worldAlignment,
+  );
+};
+
+export { default as WorldAlignment } from './WorldAlignment';
+
+/**
  Type of planes to detect in the scene.
  @discussion If set, new planes will continue to be detected and updated over time. Detected planes will be added to the session as
  ARPlaneAnchor objects. In the event that two planes are merged, the newer plane will be removed. Defaults to ARPlaneDetectionNone.

--- a/lib/ExpoTHREE.js
+++ b/lib/ExpoTHREE.js
@@ -99,6 +99,16 @@ export const getRawFeaturePoints = arSession => {
 };
 
 /**
+ Horizontal planes in the scene with respect to the frame’s origin.
+ @discussion Planes are only provided for configurations using world tracking.
+ */
+export const getPlanes = arSession => {
+  return NativeModules.ExponentGLViewManager.getPlanes(
+    arSession.sessionId,
+  );
+};
+
+/**
  Enable or disable light estimation.
  @discussion Enabled by default.
 

--- a/lib/WorldAlignment.js
+++ b/lib/WorldAlignment.js
@@ -1,0 +1,5 @@
+export default {
+  Gravity: 0,
+  GravityAndHeading: 1,
+  Camera: 2
+};


### PR DESCRIPTION
This PR adds support for planes detection and world alignment setup.

Sample usage:

```
this.planeMeshes = [];

// ...

      const { planes } = ExpoTHREE.getPlanes(arSession);

      planeMeshes.forEach(mesh => {
        this.scene.remove(mesh);
      })
      this.planeMeshes = [];

      planes.forEach(plane => {
        const geom = new THREE.PlaneGeometry(plane.extent.width, plane.extent.length, 5, 5);
        const mat = new THREE.MeshBasicMaterial({transparent: true, 
          opacity: 0.3, 
          color: 0xffff00,
          side: THREE.DoubleSide});

        const node = new THREE.Object3D();
        node.matrix.fromArray(plane.transform);
        node.matrixAutoUpdate = false;

        const mesh = new THREE.Mesh(geom, mat);
        mesh.rotation.x = THREE.Math.degToRad(-90 );
        mesh.position.set(plane.center.x, plane.center.y, plane.center.z);
        node.add(mesh);

        planeMeshes.push(node);
        this.scene.add(node);
      });
```

![plane](https://user-images.githubusercontent.com/1951843/34184151-3b2c5e48-e4ec-11e7-9f7a-b82e6695b807.png)

