### PR TITLE
Changed/updated browser-polyfill version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "author": "Nikhilesh Sigatapu",
   "license": "MIT",
   "dependencies": {
-    "@expo/browser-polyfill": "^0.0.0-alpha.4",
+    "@expo/browser-polyfill": "^0.0.1-alpha.3",
     "color-temperature": "0.2.7",
     "expo-asset-utils": "^0.0.4-alpha.2",
     "three": "0.88.0"


### PR DESCRIPTION
Fixed issue #71.
`1269 error @expo/browser-polyfill@0.0.0-alpha.10 postinstall: find ../ -name .babelrc -delete
1269 error Exit status 2
1270 error Failed at the @expo/browser-polyfill@0.0.0-alpha.10 postinstall script.
1270 error This is probably not a problem with npm. There is likely additional logging output above.
1271 verbose exit [ 2, true ]`
By updating dependency expo/browser-polyfill version to 0.0.1-alpha.3