### PR TITLE
FrameAttributes to FrameAttribute

### DIFF
--- a/lib/AR/Light.js
+++ b/lib/AR/Light.js
@@ -31,7 +31,7 @@ class Light extends THREE.PointLight {
 
   update = () => {
     const { lightEstimation } = AR.getCurrentFrame({
-      [AR.FrameAttributes.LightEstimation]: true,
+      [AR.FrameAttribute.LightEstimation]: true,
     });
     this.data = lightEstimation;
   };

--- a/lib/AR/Planes.js
+++ b/lib/AR/Planes.js
@@ -69,7 +69,7 @@ class Planes extends THREE.Object3D {
 
   update = () => {
     const { anchors } = AR.getCurrentFrame({
-      [AR.FrameAttributes.Anchors]: {},
+      [AR.FrameAttribute.Anchors]: {},
     });
     const planes = anchors.filter(({ type }) => type === AR.AnchorTypes.Plane);
     this.data = planes;

--- a/lib/AR/Points.js
+++ b/lib/AR/Points.js
@@ -38,7 +38,7 @@ class Points extends THREE.Object3D {
 
   update = () => {
     const { rawFeaturePoints } = AR.getCurrentFrame({
-      [AR.FrameAttributes.RawFeaturePoints]: true,
+      [AR.FrameAttribute.RawFeaturePoints]: true,
     });
     this.data = rawFeaturePoints;
   };

--- a/lib/AR/calculations.js
+++ b/lib/AR/calculations.js
@@ -165,7 +165,7 @@ function _getRawFeaturePoints(rawFeaturePoints) {
   let featurePoints = rawFeaturePoints;
   if (featurePoints == null) {
     const currentFrame =
-      AR.getCurrentFrame({ [AR.FrameAttributes.RawFeaturePoints]: true }) || {};
+      AR.getCurrentFrame({ [AR.FrameAttribute.RawFeaturePoints]: true }) || {};
     featurePoints = currentFrame.rawFeaturePoints;
   }
   return featurePoints || [];


### PR DESCRIPTION
In expo 2.9.0 they have dropped the `s` from a couple of constant definitions results in `undefined is not an object` errors. 

This has fixed it for me. 

I'm sure there are more instances of plural changing to singular in the expo AR component that might cause issues here. If I come across them I'll send another PR. 