### PR TITLE
Do not use removed import Expo from 'expo' syntax

### DIFF
--- a/example/screens/AR/Image.js
+++ b/example/screens/AR/Image.js
@@ -1,4 +1,4 @@
-import Expo, { AR } from 'expo';
+import { AR, Asset } from 'expo';
 import ExpoTHREE, { THREE, AR as ThreeAR } from 'expo-three';
 import React from 'react';
 import { View, Linking, TouchableOpacity, Text, Image } from 'react-native';
@@ -43,7 +43,7 @@ class ImageExample extends React.Component {
   };
 
   addDetectionImageAsync = async (resource, width = 0.254) => {
-    let asset = Expo.Asset.fromModule(resource);
+    let asset = Asset.fromModule(resource);
     await asset.downloadAsync();
     await AR.setDetectionImagesAsync({
       icon: {

--- a/example/screens/AR/Measure/index.js
+++ b/example/screens/AR/Measure/index.js
@@ -1,4 +1,4 @@
-import Expo, { AR } from 'expo';
+import { AR } from 'expo';
 import ExpoTHREE, { THREE, AR as ThreeAR } from 'expo-three';
 
 import React from 'react';

--- a/lib/resolveAsset/index.native.js
+++ b/lib/resolveAsset/index.native.js
@@ -1,5 +1,5 @@
 // @flow
-import Expo from 'expo';
+import { Asset } from 'expo';
 import { Image } from 'react-native';
 import AssetUtils from 'expo-asset-utils';
 
@@ -19,7 +19,7 @@ const resolveAsset = async fileReference => {
 
 export async function stringFromAsset(asset): Promise<string | void> {
   let url: string;
-  if (asset instanceof Expo.Asset) {
+  if (asset instanceof Asset) {
     if (!asset.localUri) {
       await asset.downloadAsync();
     }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "three": "0.88.0"
   },
   "peerDependencies": {
-    "expo": "*",
+    "expo": ">= 31.0.0",
     "react-native": "*",
     "three": "0.88.0"
   },


### PR DESCRIPTION
SDK32 removes deprecated `import Expo from 'expo'` accessors