### PR TITLE
corrected AR method names

### DIFF
--- a/example/screens/AR/Basic.js
+++ b/example/screens/AR/Basic.js
@@ -18,7 +18,7 @@ export default class App extends React.Component {
           isArEnabled
           isArRunningStateEnabled
           isArCameraStateEnabled
-          arTrackingConfiguration={AR.TrackingConfigurations.World}
+          arTrackingConfiguration={AR.TrackingConfiguration.World}
         />
         <View
           style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -29,7 +29,7 @@ export default class App extends React.Component {
   }
 
   onContextCreate = props => {
-    AR.setPlaneDetection(AR.PlaneDetectionTypes.Horizontal);
+    AR.setPlaneDetection(AR.PlaneDetection.Horizontal);
     this.commonSetup(props);
   };
 


### PR DESCRIPTION
Using the following versions:
"dependencies": {
    "expo": "^32.0.0",
    "expo-graphics": "^1.1.0",
    "expo-three": "^3.0.0-alpha.8",
    "react": "16.5.0",
    "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz"
  },
The method names have been changed in the AR Class, looking at a console log. The example from your the expo docs AR wont work, as well as this basic example.