### PR TITLE
Remove texture loader optimization to fix jpeg images

### DIFF
--- a/src/TextureLoader.ts
+++ b/src/TextureLoader.ts
@@ -2,14 +2,6 @@ import AssetUtils from 'expo-asset-utils';
 import { Platform } from 'react-native';
 import THREE from './Three';
 
-// JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
-function formatFromURI(uri: string) {
-  const isJPEG =
-    uri.search(/\.jpe?g($|\?)/i) > 0 || uri.search(/^data:image\/jpeg/) === 0;
-
-  return isJPEG ? THREE.RGBFormat : THREE.RGBAFormat;
-}
-
 export default class ExpoTextureLoader extends THREE.TextureLoader {
   load(
     asset: any,
@@ -34,9 +26,6 @@ export default class ExpoTextureLoader extends THREE.TextureLoader {
 
       function parseAsset(image) {
         texture.image = image;
-
-        // JPEGs can't have an alpha channel, so memory can be saved by storing them as RGB.
-        texture.format = formatFromURI(nativeAsset.localUri);
         texture.needsUpdate = true;
 
         if (onLoad !== undefined) {

--- a/src/TextureLoader.ts
+++ b/src/TextureLoader.ts
@@ -44,7 +44,6 @@ export default class ExpoTextureLoader extends THREE.TextureLoader {
         );
       } else {
         texture['isDataTexture'] = true; // Forces passing to `gl.texImage2D(...)` verbatim
-        texture.minFilter = THREE.LinearFilter; // Pass-through non-power-of-two
 
         parseAsset({
           data: nativeAsset,


### PR DESCRIPTION
Disable color optimization by default on jpeg images - using whatever three.js defaults to. Tested on iOS against png, jpg, and gif.

![IMG_5101](https://user-images.githubusercontent.com/9664363/83697464-ed77c580-a5b3-11ea-8e6f-86a3d77842cd.PNG)
![IMG_5102](https://user-images.githubusercontent.com/9664363/83697469-f072b600-a5b3-11ea-9903-616ce19d0fba.PNG)

fix https://github.com/expo/expo-three/issues/162
fix https://github.com/expo/expo-three/issues/138
fix https://github.com/expo/expo-three/issues/122