### PR TITLE
Drop unsupported loaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-three",
-  "version": "5.6.2",
+  "version": "5.7.0",
   "sideEffects": true,
   "description": "Utilities for using THREE.js with Expo",
   "main": "build/index.js",
@@ -50,7 +50,7 @@
     "expo-asset": "*",
     "expo-file-system": "*",
     "react-native": "*",
-    "three": "^0.117.1"
+    "three": "^0.127.0"
   },
   "devDependencies": {
     "@types/three": "^0.103.2",

--- a/src/loadAsync.ts
+++ b/src/loadAsync.ts
@@ -54,39 +54,18 @@ export default async function loadAsync(
   if (urls.length === 1) {
     if (url.match(/\.(jpeg|jpg|gif|png)$/)) {
       return loadTextureAsync({ asset });
-    } else if (url.match(/\.assimp$/i)) {
-      const arrayBuffer = await loadArrayBufferAsync({ uri: url, onProgress });
-      const AssimpLoader = loaderClassForExtension('assimp');
-      const loader = new AssimpLoader();
-      return loader.parse(arrayBuffer, onAssetRequested);
     } else if (url.match(/\.dae$/i)) {
       return loadDaeAsync({
         asset: url,
         onProgress,
         onAssetRequested,
       });
-    } else if (url.match(/\.fbx$/i)) {
-      const arrayBuffer = await loadArrayBufferAsync({ uri: url, onProgress });
-      const FBXLoader = loaderClassForExtension('fbx');
-      const loader = new FBXLoader();
-      return loader.parse(arrayBuffer, onAssetRequested);
     } else if (url.match(/\.(glb|gltf)$/i)) {
       const arrayBuffer = await loadArrayBufferAsync({ uri: url, onProgress });
       const GLTFLoader = loaderClassForExtension('gltf');
       const loader = new GLTFLoader();
       return new Promise((res, rej) =>
         loader.parse(arrayBuffer, onAssetRequested, res, rej)
-      );
-    } else if (url.match(/\.x$/i)) {
-      const XLoader = loaderClassForExtension('x');
-
-      const texLoader = {
-        path: onAssetRequested,
-        load: loadTexture,
-      };
-      const loader = new XLoader(undefined, texLoader);
-      return new Promise((res, rej) =>
-        loader.load([url, false], res, onProgress, rej)
       );
     } else if (url.match(/\.json$/i)) {
       throw new Error(

--- a/src/loaderClassForExtension.ts
+++ b/src/loaderClassForExtension.ts
@@ -1,17 +1,7 @@
-import { AMFLoader } from 'three/examples/jsm/loaders/AMFLoader';
-import { AssimpLoader } from 'three/examples/jsm/loaders/AssimpLoader';
-import { BVHLoader } from 'three/examples/jsm/loaders/BVHLoader';
 import { ColladaLoader } from 'three/examples/jsm/loaders/ColladaLoader';
-import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader';
 import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader';
-import { PCDLoader } from 'three/examples/jsm/loaders/PCDLoader';
-import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader';
-import { STLLoader } from 'three/examples/jsm/loaders/STLLoader';
-import { TDSLoader } from 'three/examples/jsm/loaders/TDSLoader';
-import { TTFLoader } from 'three/examples/jsm/loaders/TTFLoader';
-import { XLoader } from 'three/examples/jsm/loaders/XLoader';
 
 function getExtension(uri: string): string {
   const lastUriComponent = uri.split('.').pop() as string;
@@ -28,49 +18,15 @@ export function loaderClassForExtension(extension: string): any {
     throw new Error('Supplied extension is not a valid string');
   }
   switch (extension.toLowerCase()) {
-    case '3mf':
-      return TTFLoader;
-    case 'amf':
-      return AMFLoader;
-    case 'assimp':
-      return AssimpLoader;
-    case 'bvh':
-      return BVHLoader;
-    case 'ctm':
-      throw new Error(
-        'CTMLoader is deprecated. Please load it manually with three.js'
-      );
-    case 'fbx':
-      return FBXLoader;
     case 'glb':
     case 'gltf':
       return GLTFLoader;
-    case 'max':
-    case '3ds':
-      return TDSLoader;
-    case 'pcd':
-      return PCDLoader;
-    case 'ply':
-      return PLYLoader;
     case 'obj':
       return OBJLoader;
     case 'mtl':
       return MTLLoader;
     case 'dae':
       return ColladaLoader;
-    case 'stl':
-      return STLLoader;
-    case 'vtk':
-    case 'vtp':
-      throw new Error(
-        'VRMLoader is deprecated. Please load it manually with three.js'
-      );
-    case 'x':
-      return XLoader;
-
-    // case 'drc':
-    //   if (!THREE.DRACOLoader) require('three/examples/js/loaders/draco/DRACOLoader');
-    //   return THREE.DRACOLoader;
     default:
       throw new Error(
         'ExpoTHREE.loaderClassForExtension(): Unrecognized file type ' +


### PR DESCRIPTION
Drop auto loading support for:
```
import { AMFLoader } from 'three/examples/jsm/loaders/AMFLoader';
import { AssimpLoader } from 'three/examples/jsm/loaders/AssimpLoader';
import { BVHLoader } from 'three/examples/jsm/loaders/BVHLoader';
import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader';
import { PCDLoader } from 'three/examples/jsm/loaders/PCDLoader';
import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader';
import { STLLoader } from 'three/examples/jsm/loaders/STLLoader';
import { TDSLoader } from 'three/examples/jsm/loaders/TDSLoader';
import { TTFLoader } from 'three/examples/jsm/loaders/TTFLoader';
import { XLoader } from 'three/examples/jsm/loaders/XLoader';
```