### PR TITLE
Fix remote texture url for three.js >= 0.136

### DIFF
--- a/src/TextureLoader.ts
+++ b/src/TextureLoader.ts
@@ -1,5 +1,6 @@
 import { resolveAsync } from 'expo-asset-utils';
-import { Platform } from 'react-native';
+import { Platform, Image } from 'react-native';
+
 import THREE from './Three';
 
 export default class ExpoTextureLoader extends THREE.TextureLoader {
@@ -15,7 +16,7 @@ export default class ExpoTextureLoader extends THREE.TextureLoader {
       );
     }
 
-    let texture = new THREE.Texture();
+    const texture = new THREE.Texture();
 
     const loader = new THREE.ImageLoader(this.manager);
     loader.setCrossOrigin(this.crossOrigin);
@@ -43,6 +44,17 @@ export default class ExpoTextureLoader extends THREE.TextureLoader {
           onError
         );
       } else {
+        if (!nativeAsset.width || !nativeAsset.height) {
+          const { width, height } = await new Promise((res, rej) => {
+            Image.getSize(
+              nativeAsset.localUri,
+              (width: number, height: number) => res({ width, height }),
+              rej
+            );
+          });
+          nativeAsset.width = width;
+          nativeAsset.height = height;
+        }
         texture['isDataTexture'] = true; // Forces passing to `gl.texImage2D(...)` verbatim
 
         parseAsset({


### PR DESCRIPTION
# Why

Closes #236 #263

TextureLoader.load does not work if argument is an URL, with three.js >= 0.136.

Before 0.136, three.js was using `gl.texImage2D` to load textures, our cpp implementation ignores width/height if the argument is an expo asset and detects the size of the image based on the real image dimensions. After version 0.136 textures are loaded using `gl.texStorage2D` and `gl.texSubImage2D`, we are still autodetecting the correct size in `texSubImage2D`, but `texStorage2D` does not take asset as an argument so we can't handle that case on cpp side.

# How

Detect image size using `Image.getSize` from react-native

# Test plan

Using the project provided in the linked issue. Symlinking does not work, so I just copied build directory from expo-three into node_modules and verified that textures showed up correctly.