### PR TITLE
chore: Upgrade to THREE.js 0.167.0

### DIFF
--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,4 +1,5 @@
 import { Stack, Link } from 'expo-router';
+import { THREE } from 'expo-three';
 import { FlatList, Text, View } from 'react-native';
 
 // add new scenes here
@@ -42,6 +43,19 @@ export default function Page() {
           </Link>
         )}
       />
+      <View
+        style={{
+          alignItems: 'center',
+          padding: 16,
+          borderTopColor: '#cccccc',
+          borderTopWidth: 1,
+        }}
+      >
+        <Text>
+          THREE.js version:
+          <Text style={{ fontWeight: 'bold' }}> 0.{THREE.REVISION}</Text>
+        </Text>
+      </View>
     </>
   );
 }

--- a/example/package.json
+++ b/example/package.json
@@ -30,7 +30,7 @@
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",
     "react-native-web": "~0.19.12",
-    "three": "^0.166.0"
+    "three": "0.167.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",
@@ -38,13 +38,13 @@
     "@expo/webpack-config": "~19.0.1",
     "@types/react": "~18.2.79",
     "@types/react-dom": "~18.2.25",
-    "@types/three": "^0.166.0",
+    "@types/three": "0.167.0",
     "patch-package": "^8.0.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.3.3"
   },
   "resolutions": {
-    "three": "0.166.0"
+    "three": "0.167.0"
   },
   "private": true,
   "expo": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2921,10 +2921,10 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.3.tgz#705446e12ce0fad618557dd88236f51148b7a935"
   integrity sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==
 
-"@types/three@^0.166.0":
-  version "0.166.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.166.0.tgz#a220b9ffecb7b650e2fdc6ef982285e651ec5dbe"
-  integrity sha512-FHMnpcdhdbdOOIYbfkTkUVpYMW53odxbTRwd0/xJpYnTzEsjnVnondGAvHZb4z06UW0vo6WPVuvH0/9qrxKx7g==
+"@types/three@0.167.0":
+  version "0.167.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.167.0.tgz#bd15122d8ef4770571dc02a922b6f9397b54b02e"
+  integrity sha512-BC+Vbm0d6yMzct7dhTBe9ZjEh6ygupyn1k/UcZncIIS/5aNIbfvF77gQw1IFP09Oyj1UxWj0EUBBqc1GkqzsOw==
   dependencies:
     "@tweenjs/tween.js" "~23.1.2"
     "@types/stats.js" "*"
@@ -10416,10 +10416,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@0.166.0, three@^0.166.0:
-  version "0.166.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.166.0.tgz#8baa462b03430a87bdcbfed850f4d30fae0359f1"
-  integrity sha512-3Gw7oyZ/vCmz3RmNx1xuyNu7Ou/igDtoh953QsJh/QkAoi6B7jpkKwk05N8Y7/9bZeIE44zdC+i2KZNF+KWQ8A==
+three@0.167.0:
+  version "0.167.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.167.0.tgz#399ae7b69604c0a45b93ba3706ad8dc962056c42"
+  integrity sha512-9Y1a66fpjqF3rhq7ivKTaKtjQLZ97Hj/lZ00DmZWaKHaQFH4uzYT1znwRDWQOcgMmCcOloQzo61gDmqO8l9xmA==
 
 throat@^5.0.0:
   version "5.0.0"

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "expo-file-system": "*",
     "expo-gl": "*",
     "react-native": "*",
-    "three": "^0.166.0"
+    "three": "0.167.0"
   },
   "devDependencies": {
     "@types/react": "~18.2.45",
-    "@types/three": "^0.166.0",
+    "@types/three": "0.167.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "eslint": "8.17.0",
     "eslint-config-prettier": "8.5.0",
@@ -82,7 +82,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.73.6",
     "react-native-web": "~0.19.12",
-    "three": "^0.166.0"
+    "three": "0.167.0"
   },
   "jest": {
     "preset": "expo-module-scripts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,10 +2790,10 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.3.tgz#705446e12ce0fad618557dd88236f51148b7a935"
   integrity sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==
 
-"@types/three@^0.166.0":
-  version "0.166.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.166.0.tgz#a220b9ffecb7b650e2fdc6ef982285e651ec5dbe"
-  integrity sha512-FHMnpcdhdbdOOIYbfkTkUVpYMW53odxbTRwd0/xJpYnTzEsjnVnondGAvHZb4z06UW0vo6WPVuvH0/9qrxKx7g==
+"@types/three@0.167.0":
+  version "0.167.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.167.0.tgz#bd15122d8ef4770571dc02a922b6f9397b54b02e"
+  integrity sha512-BC+Vbm0d6yMzct7dhTBe9ZjEh6ygupyn1k/UcZncIIS/5aNIbfvF77gQw1IFP09Oyj1UxWj0EUBBqc1GkqzsOw==
   dependencies:
     "@tweenjs/tween.js" "~23.1.2"
     "@types/stats.js" "*"
@@ -9422,10 +9422,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.166.0:
-  version "0.166.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.166.0.tgz#8baa462b03430a87bdcbfed850f4d30fae0359f1"
-  integrity sha512-3Gw7oyZ/vCmz3RmNx1xuyNu7Ou/igDtoh953QsJh/QkAoi6B7jpkKwk05N8Y7/9bZeIE44zdC+i2KZNF+KWQ8A==
+three@0.167.0:
+  version "0.167.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.167.0.tgz#399ae7b69604c0a45b93ba3706ad8dc962056c42"
+  integrity sha512-9Y1a66fpjqF3rhq7ivKTaKtjQLZ97Hj/lZ00DmZWaKHaQFH4uzYT1znwRDWQOcgMmCcOloQzo61gDmqO8l9xmA==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Locked it to `0.167.0` and added version indicator to the example app.

Tested on android to ensure that all the examples still worked 👍 